### PR TITLE
ML Spike into feature creation

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
@@ -106,6 +106,7 @@ import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.InternalInferModelAction;
 import org.elasticsearch.xpack.core.ml.action.IsolateDatafeedAction;
 import org.elasticsearch.xpack.core.ml.action.KillProcessAction;
+import org.elasticsearch.xpack.core.ml.action.LtrFeatureExtractionAction;
 import org.elasticsearch.xpack.core.ml.action.MlInfoAction;
 import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
 import org.elasticsearch.xpack.core.ml.action.PersistJobAction;
@@ -345,6 +346,7 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
                 DeleteTrainedModelAction.INSTANCE,
                 GetTrainedModelsStatsAction.INSTANCE,
                 PutTrainedModelAction.INSTANCE,
+                LtrFeatureExtractionAction.INSTANCE,
                 // security
                 ClearRealmCacheAction.INSTANCE,
                 ClearRolesCacheAction.INSTANCE,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/LtrFeatureExtractionAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/LtrFeatureExtractionAction.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.ml.action;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.StatusToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.xpack.core.ml.ltr.RankEvalSpec;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+
+public class LtrFeatureExtractionAction extends ActionType<LtrFeatureExtractionAction.Response> {
+
+    public static final LtrFeatureExtractionAction INSTANCE = new LtrFeatureExtractionAction();
+    public static final String NAME = "cluster:admin/xpack/ml/ltr_feature_extraction";
+
+    private LtrFeatureExtractionAction() {
+        super(NAME, LtrFeatureExtractionAction.Response::new);
+    }
+
+    public static class Request extends ActionRequest implements IndicesRequest.Replaceable {
+
+        public static final ParseField NUM_DOCS = new ParseField("num_docs");
+        public static final ParseField DESTINATION = new ParseField("destination");
+        public static final ParseField RANK_EVAL_DEF = new ParseField("rank_eval_def");
+
+        private static final ConstructingObjectParser<Request, Void> PARSER =
+            new ConstructingObjectParser<>("ltr_feature_request",
+                (a) -> new Request((RankEvalSpec)a[0], (String)a[1], (Integer)a[2]));
+
+        static {
+            PARSER.declareObject(ConstructingObjectParser.constructorArg(), (p, c) -> RankEvalSpec.parse(p), RANK_EVAL_DEF);
+            PARSER.declareString(ConstructingObjectParser.constructorArg(), DESTINATION);
+            PARSER.declareInt(ConstructingObjectParser.optionalConstructorArg(), NUM_DOCS);
+        }
+
+        public static Request parseRequest(XContentParser parser) {
+            return PARSER.apply(parser, null);
+        }
+
+        private RankEvalSpec rankingEvaluationSpec;
+        private IndicesOptions indicesOptions  = SearchRequest.DEFAULT_INDICES_OPTIONS;
+        private String[] indices = Strings.EMPTY_ARRAY;
+        private SearchType searchType = SearchType.DEFAULT;
+        private String destinationIndex;
+        private int numDocs = 10;
+
+        public Request(RankEvalSpec rankingEvaluationSpec, String destinationIndex, Integer numDocs) {
+            this.rankingEvaluationSpec = Objects.requireNonNull(rankingEvaluationSpec, "ranking evaluation specification must not be null");
+            this.destinationIndex = Objects.requireNonNull(destinationIndex, "destination index must not be null");
+            if (numDocs != null) {
+                this.numDocs = numDocs;
+            }
+            indices(indices);
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            rankingEvaluationSpec = new RankEvalSpec(in);
+            indices = in.readStringArray();
+            indicesOptions = IndicesOptions.readIndicesOptions(in);
+            searchType = SearchType.fromId(in.readByte());
+            destinationIndex = in.readString();
+            numDocs = in.readVInt();
+        }
+
+        Request() {
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            ActionRequestValidationException e = null;
+            if (rankingEvaluationSpec == null) {
+                e = new ActionRequestValidationException();
+                e.addValidationError("missing ranking evaluation specification");
+            }
+            if (destinationIndex == null) {
+                e = new ActionRequestValidationException();
+                e.addValidationError("missing destination parameter");
+            }
+            return e;
+        }
+
+        /**
+         * Returns the specification of the ranking evaluation.
+         */
+        public RankEvalSpec getRankEvalSpec() {
+            return rankingEvaluationSpec;
+        }
+
+        /**
+         * Set the specification of the ranking evaluation.
+         */
+        public void setRankEvalSpec(RankEvalSpec task) {
+            this.rankingEvaluationSpec = task;
+        }
+
+        public String getDestinationIndex() {
+            return destinationIndex;
+        }
+
+        public int getNumDocs() {
+            return numDocs;
+        }
+
+        /**
+         * Sets the indices the search will be executed on.
+         */
+        @Override
+        public Request indices(String... indices) {
+            Objects.requireNonNull(indices, "indices must not be null");
+            for (String index : indices) {
+                Objects.requireNonNull(index, "index must not be null");
+            }
+            this.indices = indices;
+            return this;
+        }
+
+        /**
+         * @return the indices for this request
+         */
+        @Override
+        public String[] indices() {
+            return indices;
+        }
+
+        @Override
+        public IndicesOptions indicesOptions() {
+            return indicesOptions;
+        }
+
+        public void indicesOptions(IndicesOptions indicesOptions) {
+            this.indicesOptions = Objects.requireNonNull(indicesOptions, "indicesOptions must not be null");
+        }
+
+        /**
+         * The search type to execute, defaults to {@link SearchType#DEFAULT}.
+         */
+        public void searchType(SearchType searchType) {
+            this.searchType = Objects.requireNonNull(searchType, "searchType must not be null");
+        }
+
+        /**
+         * The type of search to execute.
+         */
+        public SearchType searchType() {
+            return searchType;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            rankingEvaluationSpec.writeTo(out);
+            out.writeStringArray(indices);
+            indicesOptions.writeIndicesOptions(out);
+            out.writeByte(searchType.id());
+            out.writeString(destinationIndex);
+            out.writeVInt(numDocs);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Request that = (Request) o;
+            return Objects.equals(indicesOptions, that.indicesOptions) &&
+                Arrays.equals(indices, that.indices) &&
+                Objects.equals(rankingEvaluationSpec, that.rankingEvaluationSpec) &&
+                Objects.equals(searchType, that.searchType) &&
+                Objects.equals(destinationIndex, that.destinationIndex) &&
+                Objects.equals(numDocs, that.numDocs);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(indicesOptions, Arrays.hashCode(indices), rankingEvaluationSpec, searchType, destinationIndex, numDocs);
+        }
+    }
+
+    public static class Response extends ActionResponse implements StatusToXContentObject {
+
+        private Map<String, ElasticsearchException> errors;
+        public Response(Map<String, ElasticsearchException> errors) {
+            this.errors = errors;
+        }
+
+        public Response(StreamInput in) throws IOException {
+            errors = in.readMap(StreamInput::readString, StreamInput::readException);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeMap(errors, StreamOutput::writeString, StreamOutput::writeException);
+        }
+
+        @Override
+        public RestStatus status() {
+            return RestStatus.OK;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("errors", errors);
+            builder.endObject();
+            return builder;
+        }
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/ltr/RankEvalSpec.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/ltr/RankEvalSpec.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.ml.ltr;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.script.Script;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+/**
+ * basically copied from the rank-eval module
+ */
+public class RankEvalSpec implements Writeable, ToXContentObject {
+    /** List of search request to use for the evaluation */
+    private final List<RatedRequest> ratedRequests;
+    /** Maximum number of requests to execute in parallel. */
+    private int maxConcurrentSearches = MAX_CONCURRENT_SEARCHES;
+    /** Default max number of requests. */
+    private static final int MAX_CONCURRENT_SEARCHES = 10;
+    /** optional: Templates to base test requests on */
+    private final Map<String, Script> templates = new HashMap<>();
+
+    public RankEvalSpec(List<RatedRequest> ratedRequests, Collection<ScriptWithId> templates) {
+        if (ratedRequests == null || ratedRequests.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Cannot evaluate ranking if no search requests with rated results are provided. Seen: " + ratedRequests);
+        }
+        this.ratedRequests = ratedRequests;
+        if (templates == null || templates.isEmpty()) {
+            for (RatedRequest request : ratedRequests) {
+                if (request.getEvaluationRequest() == null) {
+                    throw new IllegalStateException("Cannot evaluate ranking if neither template nor evaluation request is "
+                            + "provided. Seen for request id: " + request.getId());
+                }
+            }
+        }
+        if (templates != null) {
+            for (ScriptWithId idScript : templates) {
+                this.templates.put(idScript.id, idScript.script);
+            }
+        }
+    }
+
+    public RankEvalSpec(List<RatedRequest> ratedRequests) {
+        this(ratedRequests, null);
+    }
+
+    public RankEvalSpec(StreamInput in) throws IOException {
+        int specSize = in.readVInt();
+        ratedRequests = new ArrayList<>(specSize);
+        for (int i = 0; i < specSize; i++) {
+            ratedRequests.add(new RatedRequest(in));
+        }
+        int size = in.readVInt();
+        for (int i = 0; i < size; i++) {
+            String key = in.readString();
+            Script value = new Script(in);
+            this.templates.put(key, value);
+        }
+        maxConcurrentSearches = in.readVInt();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(ratedRequests.size());
+        for (RatedRequest spec : ratedRequests) {
+            spec.writeTo(out);
+        }
+        out.writeVInt(templates.size());
+        for (Entry<String, Script> entry : templates.entrySet()) {
+            out.writeString(entry.getKey());
+            entry.getValue().writeTo(out);
+        }
+        out.writeVInt(maxConcurrentSearches);
+    }
+
+    /** Returns a list of intent to query translation specifications to evaluate. */
+    public List<RatedRequest> getRatedRequests() {
+        return Collections.unmodifiableList(ratedRequests);
+    }
+
+    /** Returns the template to base test requests on. */
+    public Map<String, Script> getTemplates() {
+        return this.templates;
+    }
+
+    /** Returns the max concurrent searches allowed. */
+    public int getMaxConcurrentSearches() {
+        return this.maxConcurrentSearches;
+    }
+
+    /** Set the max concurrent searches allowed. */
+    public void setMaxConcurrentSearches(int maxConcurrentSearches) {
+        this.maxConcurrentSearches = maxConcurrentSearches;
+    }
+
+    private static final ParseField TEMPLATES_FIELD = new ParseField("templates");
+    private static final ParseField METRIC_FIELD = new ParseField("metric");
+    private static final ParseField REQUESTS_FIELD = new ParseField("requests");
+    private static final ParseField MAX_CONCURRENT_SEARCHES_FIELD = new ParseField("max_concurrent_searches");
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<RankEvalSpec, Void> PARSER = new ConstructingObjectParser<>("rank_eval",
+            a -> new RankEvalSpec((List<RatedRequest>) a[0], (Collection<ScriptWithId>) a[1]));
+
+    static {
+        PARSER.declareObjectArray(ConstructingObjectParser.constructorArg(), (p, c) -> RatedRequest.fromXContent(p), REQUESTS_FIELD);
+        PARSER.declareObjectArray(ConstructingObjectParser.optionalConstructorArg(), (p, c) -> ScriptWithId.fromXContent(p),
+                TEMPLATES_FIELD);
+        PARSER.declareInt(RankEvalSpec::setMaxConcurrentSearches, MAX_CONCURRENT_SEARCHES_FIELD);
+    }
+
+    public static RankEvalSpec parse(XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
+
+    static class ScriptWithId {
+        private Script script;
+        private String id;
+
+        private static final ParseField TEMPLATE_FIELD = new ParseField("template");
+        private static final ParseField TEMPLATE_ID_FIELD = new ParseField("id");
+
+        ScriptWithId(String id, Script script) {
+            this.id = id;
+            this.script = script;
+        }
+
+        private static final ConstructingObjectParser<ScriptWithId, Void> PARSER =
+                new ConstructingObjectParser<>("script_with_id",
+                        a -> new ScriptWithId((String) a[0], (Script) a[1]));
+
+        public static ScriptWithId fromXContent(XContentParser parser) {
+            return PARSER.apply(parser, null);
+        }
+
+        static {
+            PARSER.declareString(ConstructingObjectParser.constructorArg(), TEMPLATE_ID_FIELD);
+            PARSER.declareObject(ConstructingObjectParser.constructorArg(), (p, c) -> {
+                try {
+                    return Script.parse(p, "mustache");
+                } catch (IOException ex) {
+                    throw new ParsingException(p.getTokenLocation(), "error parsing rank request", ex);
+                }
+            }, TEMPLATE_FIELD);
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.startArray(TEMPLATES_FIELD.getPreferredName());
+        for (Entry<String, Script> entry : templates.entrySet()) {
+            builder.startObject();
+            builder.field(ScriptWithId.TEMPLATE_ID_FIELD.getPreferredName(), entry.getKey());
+            builder.field(ScriptWithId.TEMPLATE_FIELD.getPreferredName(), entry.getValue());
+            builder.endObject();
+        }
+        builder.endArray();
+
+        builder.startArray(REQUESTS_FIELD.getPreferredName());
+        for (RatedRequest spec : this.ratedRequests) {
+            spec.toXContent(builder, params);
+        }
+        builder.endArray();
+        builder.field(MAX_CONCURRENT_SEARCHES_FIELD.getPreferredName(), maxConcurrentSearches);
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        RankEvalSpec other = (RankEvalSpec) obj;
+
+        return Objects.equals(ratedRequests, other.ratedRequests) &&
+                Objects.equals(maxConcurrentSearches, other.maxConcurrentSearches) &&
+                Objects.equals(templates, other.templates);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(ratedRequests, templates, maxConcurrentSearches);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/ltr/RatedDocument.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/ltr/RatedDocument.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.ml.ltr;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * copied from rank eval
+ */
+public class RatedDocument implements Writeable, ToXContentObject {
+
+    static final ParseField RATING_FIELD = new ParseField("rating");
+    static final ParseField DOC_ID_FIELD = new ParseField("_id");
+    static final ParseField INDEX_FIELD = new ParseField("_index");
+
+    private static final ConstructingObjectParser<RatedDocument, Void> PARSER = new ConstructingObjectParser<>("rated_document",
+            a -> new RatedDocument((String) a[0], (String) a[1], (Integer) a[2]));
+
+    static {
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), INDEX_FIELD);
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), DOC_ID_FIELD);
+        PARSER.declareInt(ConstructingObjectParser.constructorArg(), RATING_FIELD);
+    }
+
+    private final int rating;
+    private final DocumentKey key;
+
+    public RatedDocument(String index, String id, int rating) {
+        this.key = new DocumentKey(index, id);
+        this.rating = rating;
+    }
+
+    RatedDocument(StreamInput in) throws IOException {
+        this.key = new DocumentKey(in.readString(), in.readString());
+        this.rating = in.readVInt();
+    }
+
+    public DocumentKey getKey() {
+        return this.key;
+    }
+
+    public String getIndex() {
+        return key.getIndex();
+    }
+
+    public String getDocID() {
+        return key.getDocId();
+    }
+
+    public int getRating() {
+        return rating;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(key.getIndex());
+        out.writeString(key.getDocId());
+        out.writeVInt(rating);
+    }
+
+    static RatedDocument fromXContent(XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(INDEX_FIELD.getPreferredName(), key.getIndex());
+        builder.field(DOC_ID_FIELD.getPreferredName(), key.getDocId());
+        builder.field(RATING_FIELD.getPreferredName(), rating);
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        RatedDocument other = (RatedDocument) obj;
+        return Objects.equals(key, other.key) && Objects.equals(rating, other.rating);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(key, rating);
+    }
+
+    /**
+     * a joint document key consisting of the documents index and id
+     */
+    public static class DocumentKey {
+
+        private final String docId;
+        private final String index;
+
+        public DocumentKey(String index, String docId) {
+            if (Strings.isNullOrEmpty(index)) {
+                throw new IllegalArgumentException("Index must be set for each rated document");
+            }
+            if (Strings.isNullOrEmpty(docId)) {
+                throw new IllegalArgumentException("DocId must be set for each rated document");
+            }
+
+            this.index = index;
+            this.docId = docId;
+        }
+
+        String getIndex() {
+            return index;
+        }
+
+        String getDocId() {
+            return docId;
+        }
+
+        @Override
+        public final boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            DocumentKey other = (DocumentKey) obj;
+            return Objects.equals(index, other.index) && Objects.equals(docId, other.docId);
+        }
+
+        @Override
+        public final int hashCode() {
+            return Objects.hash(index, docId);
+        }
+
+        @Override
+        public String toString() {
+            return "{\"_index\":\"" + index + "\",\"_id\":\"" + docId + "\"}";
+        }
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/ltr/RatedHit.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/ltr/RatedHit.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.ml.ltr;
+
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.search.SearchHit;
+
+import java.io.IOException;
+
+public class RatedHit implements ToXContentObject {
+
+    private final SearchHit hit;
+    private final Integer rating;
+    public RatedHit(SearchHit hit, Integer rating) {
+        this.hit = hit;
+        this.rating = rating;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        hit.toInnerXContent(builder, params);
+        if (rating != null) {
+            builder.field("_rating", rating);
+        }
+        builder.endObject();
+        return builder;
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/ltr/RatedRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/ltr/RatedRequest.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.ml.ltr;
+
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * copied from rank-eval
+ */
+public class RatedRequest implements Writeable, ToXContentObject {
+    private final String id;
+    private final List<String> summaryFields;
+    private final List<RatedDocument> ratedDocs;
+    /**
+     * Search request to execute for this rated request. This can be null in
+     * case the query is supplied as a template with corresponding parameters
+     */
+    @Nullable
+    private final SearchSourceBuilder evaluationRequest;
+    /**
+     * Map of parameters to use for filling a query template, can be used
+     * instead of providing testRequest.
+     */
+    private final Map<String, Object> params;
+    @Nullable
+    private String templateId;
+
+    /**
+     * Create a rated request with template ids and parameters.
+     *
+     * @param id a unique name for this rated request
+     * @param ratedDocs a list of document ratings
+     * @param params template parameters
+     * @param templateId a templare id
+     */
+    public RatedRequest(String id, List<RatedDocument> ratedDocs, Map<String, Object> params,
+            String templateId) {
+        this(id, ratedDocs, null, params, templateId);
+    }
+
+    /**
+     * Create a rated request using a {@link SearchSourceBuilder} to define the
+     * evaluated query.
+     *
+     * @param id a unique name for this rated request
+     * @param ratedDocs a list of document ratings
+     * @param evaluatedQuery the query that is evaluated
+     */
+    public RatedRequest(String id, List<RatedDocument> ratedDocs, SearchSourceBuilder evaluatedQuery) {
+        this(id, ratedDocs, evaluatedQuery, new HashMap<>(), null);
+    }
+
+    private RatedRequest(String id, List<RatedDocument> ratedDocs, SearchSourceBuilder evaluatedQuery,
+            Map<String, Object> params, String templateId) {
+        if (params != null && (params.size() > 0 && evaluatedQuery != null)) {
+            throw new IllegalArgumentException(
+                    "Ambiguous rated request: Set both, verbatim test request and test request " + "template parameters.");
+        }
+        if (templateId != null && evaluatedQuery != null) {
+            throw new IllegalArgumentException(
+                    "Ambiguous rated request: Set both, verbatim test request and test request " + "template parameters.");
+        }
+        if ((params == null || params.size() < 1) && evaluatedQuery == null) {
+            throw new IllegalArgumentException("Need to set at least test request or test request template parameters.");
+        }
+        if ((params != null && params.size() > 0) && templateId == null) {
+            throw new IllegalArgumentException("If template parameters are supplied need to set id of template to apply " + "them to too.");
+        }
+        validateEvaluatedQuery(evaluatedQuery);
+
+        // check that not two documents with same _index/id are specified
+        Set<RatedDocument.DocumentKey> docKeys = new HashSet<>();
+        for (RatedDocument doc : ratedDocs) {
+            if (docKeys.add(doc.getKey()) == false) {
+                String docKeyToString = doc.getKey().toString().replaceAll("\n", "").replaceAll("  ", " ");
+                throw new IllegalArgumentException(
+                        "Found duplicate rated document key [" + docKeyToString + "] in evaluation request [" + id + "]");
+            }
+        }
+
+        this.id = id;
+        this.evaluationRequest = evaluatedQuery;
+        this.ratedDocs = new ArrayList<>(ratedDocs);
+        if (params != null) {
+            this.params = new HashMap<>(params);
+        } else {
+            this.params = Collections.emptyMap();
+        }
+        this.templateId = templateId;
+        this.summaryFields = new ArrayList<>();
+    }
+
+    static void validateEvaluatedQuery(SearchSourceBuilder evaluationRequest) {
+        // ensure that testRequest, if set, does not contain aggregation, suggest or highlighting section
+        if (evaluationRequest != null) {
+            if (evaluationRequest.suggest() != null) {
+                throw new IllegalArgumentException("Query in rated requests should not contain a suggest section.");
+            }
+            if (evaluationRequest.aggregations() != null) {
+                throw new IllegalArgumentException("Query in rated requests should not contain aggregations.");
+            }
+            if (evaluationRequest.highlighter() != null) {
+                throw new IllegalArgumentException("Query in rated requests should not contain a highlighter section.");
+            }
+            if (evaluationRequest.explain() != null && evaluationRequest.explain()) {
+                throw new IllegalArgumentException("Query in rated requests should not use explain.");
+            }
+            if (evaluationRequest.profile()) {
+                throw new IllegalArgumentException("Query in rated requests should not use profile.");
+            }
+        }
+    }
+
+    RatedRequest(StreamInput in) throws IOException {
+        this.id = in.readString();
+        evaluationRequest = in.readOptionalWriteable(SearchSourceBuilder::new);
+
+        int intentSize = in.readInt();
+        ratedDocs = new ArrayList<>(intentSize);
+        for (int i = 0; i < intentSize; i++) {
+            ratedDocs.add(new RatedDocument(in));
+        }
+        this.params = in.readMap();
+        int summaryFieldsSize = in.readInt();
+        summaryFields = new ArrayList<>(summaryFieldsSize);
+        for (int i = 0; i < summaryFieldsSize; i++) {
+            this.summaryFields.add(in.readString());
+        }
+        this.templateId = in.readOptionalString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(id);
+        out.writeOptionalWriteable(evaluationRequest);
+
+        out.writeInt(ratedDocs.size());
+        for (RatedDocument ratedDoc : ratedDocs) {
+            ratedDoc.writeTo(out);
+        }
+        out.writeMap(params);
+        out.writeInt(summaryFields.size());
+        for (String fieldName : summaryFields) {
+            out.writeString(fieldName);
+        }
+        out.writeOptionalString(this.templateId);
+    }
+
+    public SearchSourceBuilder getEvaluationRequest() {
+        return evaluationRequest;
+    }
+
+    /** return the user supplied request id */
+    public String getId() {
+        return id;
+    }
+
+    /** return the list of rated documents to evaluate. */
+    public List<RatedDocument> getRatedDocs() {
+        return Collections.unmodifiableList(ratedDocs);
+    }
+
+    /** return the parameters if this request uses a template, otherwise this will be empty. */
+    public Map<String, Object> getParams() {
+        return Collections.unmodifiableMap(this.params);
+    }
+
+    /** return the parameters if this request uses a template, otherwise this will be {@code null}. */
+    public String getTemplateId() {
+        return this.templateId;
+    }
+
+    /** returns a list of fields that should be included in the document summary for matched documents */
+    public List<String> getSummaryFields() {
+        return Collections.unmodifiableList(summaryFields);
+    }
+
+    public void addSummaryFields(List<String> summaryFields) {
+        this.summaryFields.addAll(Objects.requireNonNull(summaryFields, "no summary fields supplied"));
+    }
+
+    private static final ParseField ID_FIELD = new ParseField("id");
+    private static final ParseField REQUEST_FIELD = new ParseField("request");
+    private static final ParseField RATINGS_FIELD = new ParseField("ratings");
+    private static final ParseField PARAMS_FIELD = new ParseField("params");
+    private static final ParseField FIELDS_FIELD = new ParseField("summary_fields");
+    private static final ParseField TEMPLATE_ID_FIELD = new ParseField("template_id");
+
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<RatedRequest, Void> PARSER = new ConstructingObjectParser<>("request",
+            a -> new RatedRequest((String) a[0], (List<RatedDocument>) a[1], (SearchSourceBuilder) a[2], (Map<String, Object>) a[3],
+                    (String) a[4]));
+
+    static {
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), ID_FIELD);
+        PARSER.declareObjectArray(ConstructingObjectParser.constructorArg(), (p, c) -> {
+            return RatedDocument.fromXContent(p);
+        }, RATINGS_FIELD);
+        PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), (p, c) ->
+                SearchSourceBuilder.fromXContent(p, false), REQUEST_FIELD);
+        PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), (p, c) -> p.map(), PARAMS_FIELD);
+        PARSER.declareStringArray(RatedRequest::addSummaryFields, FIELDS_FIELD);
+        PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), TEMPLATE_ID_FIELD);
+    }
+
+    /**
+     * parse from rest representation
+     */
+    public static RatedRequest fromXContent(XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(ID_FIELD.getPreferredName(), this.id);
+        if (evaluationRequest != null) {
+            builder.field(REQUEST_FIELD.getPreferredName(), this.evaluationRequest);
+        }
+        builder.startArray(RATINGS_FIELD.getPreferredName());
+        for (RatedDocument doc : this.ratedDocs) {
+            doc.toXContent(builder, params);
+        }
+        builder.endArray();
+        if (this.templateId != null) {
+            builder.field(TEMPLATE_ID_FIELD.getPreferredName(), this.templateId);
+        }
+        if (this.params.isEmpty() == false) {
+            builder.startObject(PARAMS_FIELD.getPreferredName());
+            for (Entry<String, Object> entry : this.params.entrySet()) {
+                builder.field(entry.getKey(), entry.getValue());
+            }
+            builder.endObject();
+        }
+        if (this.summaryFields.isEmpty() == false) {
+            builder.startArray(FIELDS_FIELD.getPreferredName());
+            for (String field : this.summaryFields) {
+                builder.value(field);
+            }
+            builder.endArray();
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        RatedRequest other = (RatedRequest) obj;
+
+        return Objects.equals(id, other.id) && Objects.equals(evaluationRequest, other.evaluationRequest)
+                && Objects.equals(summaryFields, other.summaryFields)
+                && Objects.equals(ratedDocs, other.ratedDocs)
+                && Objects.equals(params, other.params)
+                && Objects.equals(templateId, other.templateId);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(id, evaluationRequest, summaryFields, ratedDocs, params,
+                templateId);
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -99,6 +99,7 @@ import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.InternalInferModelAction;
 import org.elasticsearch.xpack.core.ml.action.IsolateDatafeedAction;
 import org.elasticsearch.xpack.core.ml.action.KillProcessAction;
+import org.elasticsearch.xpack.core.ml.action.LtrFeatureExtractionAction;
 import org.elasticsearch.xpack.core.ml.action.MlInfoAction;
 import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
 import org.elasticsearch.xpack.core.ml.action.PersistJobAction;
@@ -170,6 +171,7 @@ import org.elasticsearch.xpack.ml.action.TransportGetTrainedModelsStatsAction;
 import org.elasticsearch.xpack.ml.action.TransportInternalInferModelAction;
 import org.elasticsearch.xpack.ml.action.TransportIsolateDatafeedAction;
 import org.elasticsearch.xpack.ml.action.TransportKillProcessAction;
+import org.elasticsearch.xpack.ml.action.TransportLtrFeatureExtractionAction;
 import org.elasticsearch.xpack.ml.action.TransportMlInfoAction;
 import org.elasticsearch.xpack.ml.action.TransportOpenJobAction;
 import org.elasticsearch.xpack.ml.action.TransportPersistJobAction;
@@ -289,6 +291,7 @@ import org.elasticsearch.xpack.ml.rest.job.RestOpenJobAction;
 import org.elasticsearch.xpack.ml.rest.job.RestPostDataAction;
 import org.elasticsearch.xpack.ml.rest.job.RestPostJobUpdateAction;
 import org.elasticsearch.xpack.ml.rest.job.RestPutJobAction;
+import org.elasticsearch.xpack.ml.rest.ltr.RestLtfFeatureExtractionAction;
 import org.elasticsearch.xpack.ml.rest.modelsnapshots.RestDeleteModelSnapshotAction;
 import org.elasticsearch.xpack.ml.rest.modelsnapshots.RestGetModelSnapshotsAction;
 import org.elasticsearch.xpack.ml.rest.modelsnapshots.RestRevertModelSnapshotAction;
@@ -771,6 +774,7 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin, Analys
             new RestDeleteTrainedModelAction(),
             new RestGetTrainedModelsStatsAction(),
             new RestPutTrainedModelAction(),
+            new RestLtfFeatureExtractionAction(),
             // CAT Handlers
             new RestCatJobsAction(),
             new RestCatTrainedModelsAction(),
@@ -852,6 +856,7 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin, Analys
                 new ActionHandler<>(DeleteTrainedModelAction.INSTANCE, TransportDeleteTrainedModelAction.class),
                 new ActionHandler<>(GetTrainedModelsStatsAction.INSTANCE, TransportGetTrainedModelsStatsAction.class),
                 new ActionHandler<>(PutTrainedModelAction.INSTANCE, TransportPutTrainedModelAction.class),
+                new ActionHandler<>(LtrFeatureExtractionAction.INSTANCE, TransportLtrFeatureExtractionAction.class),
                 usageAction,
                 infoAction);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportLtrFeatureExtractionAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportLtrFeatureExtractionAction.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.action;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.search.MultiSearchRequest;
+import org.elasticsearch.action.search.MultiSearchResponse;
+import org.elasticsearch.action.search.MultiSearchResponse.Item;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.TemplateScript;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.ml.action.LtrFeatureExtractionAction;
+import org.elasticsearch.xpack.core.ml.ltr.RankEvalSpec;
+import org.elasticsearch.xpack.core.ml.ltr.RatedHit;
+import org.elasticsearch.xpack.core.ml.ltr.RatedDocument;
+import org.elasticsearch.xpack.core.ml.ltr.RatedRequest;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import static org.elasticsearch.common.xcontent.XContentHelper.createParser;
+
+/**
+ * copied from the rank-eval module
+ */
+public class TransportLtrFeatureExtractionAction
+    extends HandledTransportAction<LtrFeatureExtractionAction.Request, LtrFeatureExtractionAction.Response> {
+    private final Client client;
+    private static final Logger logger = LogManager.getLogger(TransportLtrFeatureExtractionAction.class);
+    private final ScriptService scriptService;
+    private final NamedXContentRegistry namedXContentRegistry;
+
+    @Inject
+    public TransportLtrFeatureExtractionAction(ActionFilters actionFilters, Client client, TransportService transportService,
+                                               ScriptService scriptService, NamedXContentRegistry namedXContentRegistry) {
+        super(LtrFeatureExtractionAction.NAME, transportService, actionFilters, LtrFeatureExtractionAction.Request::new);
+        this.scriptService = scriptService;
+        this.namedXContentRegistry = namedXContentRegistry;
+        this.client = client;
+    }
+
+    @Override
+    protected void doExecute(Task task, LtrFeatureExtractionAction.Request request, ActionListener<LtrFeatureExtractionAction.Response> listener) {
+        RankEvalSpec evaluationSpecification = request.getRankEvalSpec();
+
+        List<RatedRequest> ratedRequests = evaluationSpecification.getRatedRequests();
+        Map<String, ElasticsearchException> errors = new ConcurrentHashMap<>(ratedRequests.size());
+        List<RatedRequest> ratedRequestsInSearch = new ArrayList<>();
+        Map<String, TemplateScript.Factory> scriptsWithoutParams = new HashMap<>();
+        for (Map.Entry<String, Script> entry : evaluationSpecification.getTemplates().entrySet()) {
+            scriptsWithoutParams.put(entry.getKey(), scriptService.compile(entry.getValue(), TemplateScript.CONTEXT));
+        }
+        MultiSearchRequest initialMultiSearch = new MultiSearchRequest();
+        initialMultiSearch.maxConcurrentSearchRequests(evaluationSpecification.getMaxConcurrentSearches());
+        for (RatedRequest ratedRequest : ratedRequests) {
+            SearchSourceBuilder evaluationRequest = ratedRequest.getEvaluationRequest();
+            if (evaluationRequest == null) {
+                Map<String, Object> params = ratedRequest.getParams();
+                String templateId = ratedRequest.getTemplateId();
+                TemplateScript.Factory templateScript = scriptsWithoutParams.get(templateId);
+                String resolvedRequest = templateScript.newInstance(params).execute();
+                try (XContentParser subParser = createParser(namedXContentRegistry,
+                    LoggingDeprecationHandler.INSTANCE, new BytesArray(resolvedRequest), XContentType.JSON)) {
+                    evaluationRequest = SearchSourceBuilder.fromXContent(subParser, false);
+                } catch (IOException e) {
+                    listener.onFailure(new ElasticsearchException("Failed parsing query for request [" + ratedRequest.getId() + "]", e));
+                    return;
+                }
+            }
+
+            evaluationRequest.size(request.getNumDocs());
+            ratedRequestsInSearch.add(ratedRequest);
+            List<String> summaryFields = ratedRequest.getSummaryFields();
+            if (summaryFields.isEmpty()) {
+                evaluationRequest.fetchSource(false);
+            } else {
+                evaluationRequest.fetchSource(summaryFields.toArray(new String[0]), new String[0]);
+            }
+            SearchRequest searchRequest = new SearchRequest(request.indices(), evaluationRequest);
+            searchRequest.indicesOptions(request.indicesOptions());
+            searchRequest.searchType(request.searchType());
+            initialMultiSearch.add(searchRequest);
+        }
+        if (initialMultiSearch.requests().isEmpty()) {
+            listener.onResponse(new LtrFeatureExtractionAction.Response(errors));
+            logger.info("no search took place for request");
+            return;
+        }
+
+        ActionListener<MultiSearchResponse> handleFirstMSearchResponse = ActionListener.wrap(
+            multiSearchResponse -> {
+                int responsePosition = 0;
+                BulkRequest bulkRequest = new BulkRequest();
+                Map<String, CategorizedHits> specificationAndHits = new HashMap<>();
+                List<RatedRequest> unmetSpecifications = new ArrayList<>();
+                MultiSearchRequest mSearchForUnmatched = new MultiSearchRequest();
+                mSearchForUnmatched.maxConcurrentSearchRequests(request.getRankEvalSpec().getMaxConcurrentSearches());
+                for (Item response : multiSearchResponse.getResponses()) {
+                    RatedRequest specification = ratedRequestsInSearch.get(responsePosition++);
+                    List<RatedDocument> docs = specification.getRatedDocs();
+                    if (response.isFailure()) {
+                        errors.put(specification.getId(), new ElasticsearchException(response.getFailure()));
+                        continue;
+                    }
+                    SearchHit[] hits = response.getResponse().getHits().getHits();
+                    CategorizedHits categorizedHits = joinHitsWithRatings(hits, docs);
+                    if (categorizedHits.ratingsWithoutHits.isEmpty() == false) {
+                        mSearchForUnmatched.add(buildSearchRequestFromUnmetRatings(request,
+                            specification,
+                            categorizedHits.ratingsWithoutHits));
+                        unmetSpecifications.add(specification);
+                        specificationAndHits.put(specification.getId(), categorizedHits);
+                        continue;
+                    }
+                    // We don't have to worry about unmet ranked docs for this rating request
+                    // Add it to our bulk indexing
+                    EvalDoc evalDoc = new EvalDoc(specification.getId(), categorizedHits);
+                    addEvalDocToBulkRequest(evalDoc, bulkRequest, request.getDestinationIndex(), errors);
+                }
+                assert unmetSpecifications.size() == mSearchForUnmatched.requests().size();
+                if (bulkRequest.requests().isEmpty()) {
+                    logger.info("bulk requests are empty. errors [" + errors + "]");
+                    if (unmetSpecifications.isEmpty()) {
+                        logger.info("no unmatched specifications");
+                        listener.onResponse(new LtrFeatureExtractionAction.Response(errors));
+                        return;
+                    }
+                    handleUnmetSpecifications(mSearchForUnmatched,
+                        unmetSpecifications,
+                        specificationAndHits,
+                        request.getDestinationIndex(),
+                        errors,
+                        listener);
+                } else {
+                    client.bulk(bulkRequest, ActionListener.wrap(
+                        bulkResponse -> {
+                            if (bulkResponse.hasFailures()) {
+                                errors.put("initial_bulk_indexing_failures", new ElasticsearchException(bulkResponse.buildFailureMessage()));
+                            }
+                            if (unmetSpecifications.isEmpty()) {
+                                listener.onResponse(new LtrFeatureExtractionAction.Response(errors));
+                            } else {
+                                handleUnmetSpecifications(mSearchForUnmatched,
+                                    unmetSpecifications,
+                                    specificationAndHits,
+                                    request.getDestinationIndex(),
+                                    errors,
+                                    listener);
+                            }
+                        },
+                        listener::onFailure
+                    ));
+                }
+            },
+            listener::onFailure
+        );
+        assert ratedRequestsInSearch.size() == initialMultiSearch.requests().size();
+        client.multiSearch(initialMultiSearch, handleFirstMSearchResponse);
+    }
+
+    void addEvalDocToBulkRequest(EvalDoc evalDoc, BulkRequest bulkRequest, String dest, Map<String, ElasticsearchException> errors) {
+        try {
+            BytesReference reference = XContentHelper.toXContent(evalDoc, XContentType.JSON, false);
+            bulkRequest.add(client.prepareIndex(dest)
+                .setId(evalDoc.specificationId)
+                .setSource(reference, XContentType.JSON)
+                .request());
+        } catch (IOException ex) {
+            errors.put(evalDoc.specificationId, new ElasticsearchException(ex));
+        }
+    }
+
+    void handleUnmetSpecifications(MultiSearchRequest msearchRequest,
+                                   List<RatedRequest> unmetSpecifications,
+                                   Map<String, CategorizedHits> specificationAndHits,
+                                   String destination,
+                                   Map<String, ElasticsearchException> errors,
+                                   ActionListener<LtrFeatureExtractionAction.Response> listener) {
+        client.multiSearch(msearchRequest, ActionListener.wrap(
+            multiSearchResponse -> {
+                BulkRequest bulkRequest = new BulkRequest();
+                int currResponse = 0;
+                for (Item response : multiSearchResponse.getResponses()) {
+                    RatedRequest specification = unmetSpecifications.get(currResponse++);
+                    if (response.isFailure()) {
+                        errors.put(specification.getId(), new ElasticsearchException(response.getFailure()));
+                        continue;
+                    }
+                    List<RatedDocument> docs = specification.getRatedDocs();
+                    SearchHit[] hits = response.getResponse().getHits().getHits();
+                    CategorizedHits categorizedHits = joinHitsWithRatings(hits, docs);
+                    CategorizedHits originalHits = specificationAndHits.get(specification.getId());
+
+                    assert originalHits != null;
+
+                    // We don't have to worry about unmet ranked docs for this rating request
+                    // Add it to our bulk indexing
+                    EvalDoc evalDoc = new EvalDoc(specification.getId(),
+                        originalHits.ratedHits,
+                        originalHits.unrankedHits,
+                        categorizedHits.ratedHits);
+                    addEvalDocToBulkRequest(evalDoc, bulkRequest, destination, errors);
+                }
+                if (bulkRequest.requests().isEmpty()) {
+                    logger.info("bulk request for unmet specifications is empty. Errors [" + errors + "]");
+                    listener.onResponse(new LtrFeatureExtractionAction.Response(errors));
+                    return;
+                }
+                client.bulk(bulkRequest, ActionListener.wrap(
+                    bulkResponse -> {
+                        if (bulkResponse.hasFailures()) {
+                            errors.put("bulk_indexing_failures", new ElasticsearchException(bulkResponse.buildFailureMessage()));
+                        }
+                        listener.onResponse(new LtrFeatureExtractionAction.Response(errors));
+                    },
+                    listener::onFailure
+                ));
+            },
+            listener::onFailure
+        ));
+    }
+
+    /**
+     * Joins hits with rated documents using the joint _index/_id document key.
+     */
+    static CategorizedHits joinHitsWithRatings(SearchHit[] hits, List<RatedDocument> ratedDocs) {
+        Map<RatedDocument.DocumentKey, RatedDocument> ratedDocumentMap = ratedDocs.stream()
+            .collect(Collectors.toMap(RatedDocument::getKey, item -> item));
+        List<RatedHit> ratedSearchHits = new ArrayList<>(hits.length);
+        List<RatedHit> hitsWithoutRanking = new ArrayList<>();
+        Set<RatedDocument> ratingsWithHits = new HashSet<>();
+        for (SearchHit hit : hits) {
+            RatedDocument.DocumentKey key = new RatedDocument.DocumentKey(hit.getIndex(), hit.getId());
+            RatedDocument ratedDoc = ratedDocumentMap.get(key);
+            if (ratedDoc != null) {
+                ratedSearchHits.add(new RatedHit(hit, ratedDoc.getRating()));
+                ratingsWithHits.add(ratedDoc);
+            } else {
+                hitsWithoutRanking.add(new RatedHit(hit, null));
+            }
+        }
+        CategorizedHits categorizedHits = new CategorizedHits();
+        categorizedHits.ratedHits = ratedSearchHits;
+        List<RatedDocument> ratingsWithoutHits = ratedDocs.stream()
+            .filter(rd -> ratingsWithHits.contains(rd) == false)
+            .collect(Collectors.toList());
+        categorizedHits.ratingsWithoutHits = ratingsWithoutHits;
+        categorizedHits.unrankedHits = hitsWithoutRanking;
+        return categorizedHits;
+    }
+
+    static SearchRequest buildSearchRequestFromUnmetRatings(LtrFeatureExtractionAction.Request request,
+                                                            RatedRequest ratedRequest,
+                                                            List<RatedDocument> ratedDocuments) {
+        //TODO what about doc ids that match two different docs in different indices?
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
+            .size(ratedDocuments.size())
+            .query(QueryBuilders.boolQuery()
+                .filter(QueryBuilders.idsQuery()
+                .addIds(ratedDocuments.stream().map(RatedDocument::getDocID).toArray(String[]::new))));
+        List<String> summaryFields = ratedRequest.getSummaryFields();
+        if (summaryFields.isEmpty()) {
+            searchSourceBuilder.fetchSource(false);
+        } else {
+            searchSourceBuilder.fetchSource(summaryFields.toArray(new String[0]), new String[0]);
+        }
+        SearchRequest searchRequest = new SearchRequest(request.indices(), searchSourceBuilder);
+        searchRequest.indicesOptions(request.indicesOptions());
+        return searchRequest;
+    }
+
+    private static class CategorizedHits {
+        List<RatedHit> ratedHits;
+        List<RatedDocument> ratingsWithoutHits;
+        List<RatedHit> unrankedHits;
+    }
+
+    private static class EvalDoc implements ToXContentObject {
+
+        private final String specificationId;
+        private final List<RatedHit> ratedHits;
+        private final List<RatedHit> unrankedHits;
+        private final List<RatedHit> rankedWithoutHit;
+
+        public EvalDoc(String specificationId, CategorizedHits categorizedHits) {
+            this(specificationId, categorizedHits.ratedHits, categorizedHits.unrankedHits, Collections.emptyList());
+        }
+        public EvalDoc(String specificationId,
+                       List<RatedHit> ratedHits,
+                       List<RatedHit> unrankedHits,
+                       List<RatedHit> rankedWithoutHit) {
+            this.specificationId = specificationId;
+            this.ratedHits = ratedHits;
+            this.unrankedHits = unrankedHits;
+            this.rankedWithoutHit = rankedWithoutHit;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("specification_id", specificationId);
+            if (ratedHits.size() > 0) {
+                builder.field("rated_hits", ratedHits);
+            }
+            if (unrankedHits.size() > 0) {
+                builder.field("unrated_hits", unrankedHits);
+            }
+            if (rankedWithoutHit.size() > 0) {
+                builder.field("rated_without_hits", rankedWithoutHit);
+            }
+            builder.endObject();
+            return builder;
+        }
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/ltr/RestLtfFeatureExtractionAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/ltr/RestLtfFeatureExtractionAction.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.rest.ltr;
+
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.ml.action.LtrFeatureExtractionAction;
+import org.elasticsearch.xpack.ml.MachineLearning;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+
+public class RestLtfFeatureExtractionAction extends BaseRestHandler {
+
+    public static String ENDPOINT = MachineLearning.BASE_PATH + "ltr/_feature_creation";
+
+    @Override
+    public List<Route> routes() {
+        return List.of(
+            new Route(GET, ENDPOINT),
+            new Route(POST, ENDPOINT),
+            new Route(GET, ENDPOINT + "/{index}" ),
+            new Route(POST, ENDPOINT + "/{index}"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+        XContentParser parser = restRequest.contentParser();
+        LtrFeatureExtractionAction.Request request  = LtrFeatureExtractionAction.Request.parseRequest(parser);
+        request.indices(Strings.splitStringByCommaToArray(restRequest.param("index")));
+        request.indicesOptions(IndicesOptions.fromRequest(restRequest, request.indicesOptions()));
+        if (restRequest.hasParam("search_type")) {
+            request.searchType(SearchType.fromString(restRequest.param("search_type")));
+        }
+        return channel -> client.execute(LtrFeatureExtractionAction.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+
+    @Override
+    public String getName() {
+        return "ltr_feature_extraction";
+    }
+}


### PR DESCRIPTION
# HERE THERE BE DRAGONS. CODE ONLY MANUALLY TESTED

This is a minor spike into creating feature sets for LTR. 

All the code is effectively a copy of rank eval with some twists:

- there are no metrics
- results are written to the destination index

Fields written:
- `specification_id`: The id of that given query + ratings specification
- `rated_hits`: Hits that were found and had a rating (rating is written as `_rating` field)
- `unrated_hits`: Hits that were returned but did not have a rating
- `rated_without_hits`: A rating that was provided but did not have any hits in the top K 

Example usage:
```
POST _ml/ltr/_feature_creation/kibana_sample_data_flights
{
  "rank_eval_def": {
    "requests": [
      {
        "summary_fields": ["DestCountry"],
        "id": "aussies",
        "request": {
          "query": {
            "match": {
              "DestCountry": "AU"
            }
          }
        },
        "ratings": [
          {"_id": "sbF7iHABhckmhA0IScHe", "_index": "kibana_sample_data_flights", "rating": 1},
          {"_id": "E7F7iHABhckmhA0IScLf", "_index": "kibana_sample_data_flights", "rating": 2},
          {"_id": "M7F7iHABhckmhA0IScPh", "_index": "kibana_sample_data_flights", "rating": 2}
          ]
      },
      {
        "summary_fields": ["DestCountry"],
        "id": "italy",
        "request": {
          "query": {
            "match": {
              "DestCountry": "IT"
            }
          }
        },
        "ratings": [
          {"_id": "srF7iHABhckmhA0IScHf", "_index": "kibana_sample_data_flights", "rating": 1},
          {"_id": "M7F7iHABhckmhA0IScPh", "_index": "kibana_sample_data_flights", "rating": 1}
          ]
      }
    ]
  },
  "num_docs": 3,
  "destination": "boom"
}
```

Here, I am asking for these queries to be ran, and then the resulting hits paired up with their respective ratings. 

After this particular call, the results in the index looked like:
```
[
      {
        "_index" : "boom",
        "_id" : "aussies",
        "_score" : 1.0,
        "_source" : {
          "specification_id" : "aussies",
          "rated_hits" : [
            {
              "_index" : "kibana_sample_data_flights",
              "_id" : "sbF7iHABhckmhA0IScHe",
              "_score" : 3.4454226,
              "_source" : {
                "DestCountry" : "AU"
              },
              "_rating" : 1
            },
            {
              "_index" : "kibana_sample_data_flights",
              "_id" : "E7F7iHABhckmhA0IScLf",
              "_score" : 3.4454226,
              "_source" : {
                "DestCountry" : "AU"
              },
              "_rating" : 2
            }
          ],
          "rated_without_hits" : [
            {
              "_index" : "kibana_sample_data_flights",
              "_id" : "M7F7iHABhckmhA0IScPh",
              "_score" : 0.0,
              "_source" : {
                "DestCountry" : "AU"
              },
              "_rating" : 2
            }
          ]
        }
      },
      {
        "_index" : "boom",
        "_id" : "italy",
        "_score" : 1.0,
        "_source" : {
          "specification_id" : "italy",
          "rated_hits" : [
            {
              "_index" : "kibana_sample_data_flights",
              "_id" : "srF7iHABhckmhA0IScHf",
              "_score" : 1.7060313,
              "_source" : {
                "DestCountry" : "IT"
              },
              "_rating" : 1
            }
          ],
          "unrated_hits" : [
            {
              "_index" : "kibana_sample_data_flights",
              "_id" : "s7F7iHABhckmhA0IScHf",
              "_score" : 1.7060313,
              "_source" : {
                "DestCountry" : "IT"
              }
            }
          ],
          "rated_without_hits" : [
            {
              "_index" : "kibana_sample_data_flights",
              "_id" : "M7F7iHABhckmhA0IScPh",
              "_score" : 0.0,
              "_source" : {
                "DestCountry" : "AU"
              },
              "_rating" : 1
            }
          ]
        }
      }
    ]
```