### PR TITLE
Experiment/correlation

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartInvestigationAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartInvestigationAction.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ml.action;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class StartInvestigationAction extends ActionType<StartInvestigationAction.Response> {
+
+    public static final StartInvestigationAction INSTANCE = new StartInvestigationAction();
+
+    public static final String NAME = "cluster:monitor/xpack/ml/investigation/start";
+
+    private StartInvestigationAction() {
+        super(NAME, StartInvestigationAction.Response::new);
+    }
+
+    public static class Request extends ActionRequest {
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+    }
+
+    public static class Response extends ActionResponse implements ToXContentObject  {
+
+        private final List<Map<String, Object>> items;
+        public Response(List<Map<String, Object>> items) {
+            this.items = items;
+        }
+
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            items = in.readList(StreamInput::readMap);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("results", items);
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeCollection(items, StreamOutput::writeMap);
+        }
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartInvestigationAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartInvestigationAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.ml.investigation.InvestigationConfig;
 
 import java.io.IOException;
 import java.util.List;
@@ -31,9 +32,30 @@ public class StartInvestigationAction extends ActionType<StartInvestigationActio
     }
 
     public static class Request extends ActionRequest {
+
+        private final InvestigationConfig config;
+        public Request(InvestigationConfig config) {
+            this.config = config;
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.config = new InvestigationConfig(in);
+        }
+
+        public InvestigationConfig getConfig() {
+            return config;
+        }
+
         @Override
         public ActionRequestValidationException validate() {
             return null;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            this.config.writeTo(out);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartInvestigationAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartInvestigationAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.ml.investigation.InvestigationConfig;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -61,8 +62,8 @@ public class StartInvestigationAction extends ActionType<StartInvestigationActio
 
     public static class Response extends ActionResponse implements ToXContentObject  {
 
-        private final List<Map<String, Object>> items;
-        public Response(List<Map<String, Object>> items) {
+        private final Collection<Map<String, Object>> items;
+        public Response(Collection<Map<String, Object>> items) {
             this.items = items;
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/investigation/InvestigationConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/investigation/InvestigationConfig.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ml.investigation;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+
+public class InvestigationConfig implements ToXContentObject, Writeable {
+
+    public static ParseField KEY_INDICATOR = new ParseField("key_indicator");
+    public static ParseField TERMS = new ParseField("terms");
+
+    public static ObjectParser<InvestigationConfig, Void> PARSER = new ObjectParser<InvestigationConfig, Void>(
+        "investigation_config",
+        InvestigationConfig::new
+    );
+
+    static {
+        PARSER.declareString(InvestigationConfig::setKeyIndicator, KEY_INDICATOR);
+        PARSER.declareStringArray(InvestigationConfig::setTerms, TERMS);
+    }
+
+    private String keyIndicator;
+    private List<String> terms;
+
+    public InvestigationConfig() {
+
+    }
+
+    public String getKeyIndicator() {
+        return keyIndicator;
+    }
+
+    public InvestigationConfig setKeyIndicator(String keyIndicator) {
+        this.keyIndicator = keyIndicator;
+        return this;
+    }
+
+    public List<String> getTerms() {
+        return terms;
+    }
+
+    public InvestigationConfig setTerms(List<String> terms) {
+        this.terms = terms;
+        return this;
+    }
+
+    public InvestigationConfig(StreamInput in) throws IOException {
+        this.keyIndicator = in.readString();
+        this.terms = in.readStringList();
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return null;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(keyIndicator);
+        out.writeStringCollection(terms);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/investigation/InvestigationConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/investigation/InvestigationConfig.java
@@ -22,6 +22,7 @@ public class InvestigationConfig implements ToXContentObject, Writeable {
 
     public static ParseField KEY_INDICATOR = new ParseField("key_indicator");
     public static ParseField TERMS = new ParseField("terms");
+    public static ParseField SOURCE_CONFIG = new ParseField("source_config");
 
     public static ObjectParser<InvestigationConfig, Void> PARSER = new ObjectParser<InvestigationConfig, Void>(
         "investigation_config",
@@ -31,10 +32,12 @@ public class InvestigationConfig implements ToXContentObject, Writeable {
     static {
         PARSER.declareString(InvestigationConfig::setKeyIndicator, KEY_INDICATOR);
         PARSER.declareStringArray(InvestigationConfig::setTerms, TERMS);
+        PARSER.declareObject(InvestigationConfig::setSourceConfig, InvestigationSource.createParser(false), SOURCE_CONFIG);
     }
 
     private String keyIndicator;
     private List<String> terms;
+    private InvestigationSource sourceConfig;
 
     public InvestigationConfig() {
 
@@ -61,6 +64,15 @@ public class InvestigationConfig implements ToXContentObject, Writeable {
     public InvestigationConfig(StreamInput in) throws IOException {
         this.keyIndicator = in.readString();
         this.terms = in.readStringList();
+    }
+
+    public InvestigationConfig setSourceConfig(InvestigationSource sourceConfig) {
+        this.sourceConfig = sourceConfig;
+        return this;
+    }
+
+    public InvestigationSource getSourceConfig() {
+        return sourceConfig;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/investigation/InvestigationSource.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/investigation/InvestigationSource.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.core.ml.investigation;
+
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.core.ml.utils.RuntimeMappingsValidator;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class InvestigationSource implements Writeable, ToXContentObject {
+
+    public static final ParseField INDEX = new ParseField("index");
+    public static final ParseField QUERY = new ParseField("query");
+
+    @SuppressWarnings({ "unchecked"})
+    public static ConstructingObjectParser<InvestigationSource, Void> createParser(boolean ignoreUnknownFields) {
+        ConstructingObjectParser<InvestigationSource, Void> parser = new ConstructingObjectParser<>("investigation_source",
+            ignoreUnknownFields, a -> new InvestigationSource(
+                ((List<String>) a[0]).toArray(new String[0]),
+                (QueryBuilder) a[1],
+                (Map<String, Object>) a[2]));
+        parser.declareStringArray(ConstructingObjectParser.constructorArg(), INDEX);
+        parser.declareObject(ConstructingObjectParser.optionalConstructorArg(),
+            (p, c) -> AbstractQueryBuilder.parseInnerQueryBuilder(p),
+            QUERY);
+        parser.declareObject(ConstructingObjectParser.optionalConstructorArg(), (p, c) -> p.map(),
+            SearchSourceBuilder.RUNTIME_MAPPINGS_FIELD);
+        return parser;
+    }
+
+    private final String[] index;
+    private final QueryBuilder queryProvider;
+    private final Map<String, Object> runtimeMappings;
+
+    public InvestigationSource(String[] index, @Nullable QueryBuilder queryProvider, @Nullable Map<String, Object> runtimeMappings) {
+        this.index = ExceptionsHelper.requireNonNull(index, INDEX);
+        if (index.length == 0) {
+            throw new IllegalArgumentException("source.index must specify at least one index");
+        }
+        if (Arrays.stream(index).anyMatch(Strings::isNullOrEmpty)) {
+            throw new IllegalArgumentException("source.index must contain non-null and non-empty strings");
+        }
+        this.queryProvider = queryProvider == null ? QueryBuilders.matchAllQuery() : queryProvider;
+        this.runtimeMappings = runtimeMappings == null ? Collections.emptyMap() : Collections.unmodifiableMap(runtimeMappings);
+        RuntimeMappingsValidator.validate(this.runtimeMappings);
+    }
+
+    public InvestigationSource(StreamInput in) throws IOException {
+        index = in.readStringArray();
+        queryProvider = in.readNamedWriteable(QueryBuilder.class);
+        runtimeMappings = in.readMap();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeStringArray(index);
+        out.writeNamedWriteable(queryProvider);
+        out.writeMap(runtimeMappings);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.array(INDEX.getPreferredName(), index);
+        builder.field(QUERY.getPreferredName(), queryProvider);
+        if (runtimeMappings.isEmpty() == false) {
+            builder.field(SearchSourceBuilder.RUNTIME_MAPPINGS_FIELD.getPreferredName(), runtimeMappings);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        InvestigationSource other = (InvestigationSource) o;
+        return Arrays.equals(index, other.index)
+            && Objects.equals(queryProvider, other.queryProvider)
+            && Objects.equals(runtimeMappings, other.runtimeMappings);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(Arrays.asList(index), queryProvider, runtimeMappings);
+    }
+
+    public String[] getIndex() {
+        return index;
+    }
+
+    public QueryBuilder getQuery() {
+        return queryProvider;
+    }
+
+    public Map<String, Object> getRuntimeMappings() {
+        return runtimeMappings;
+    }
+
+}

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -67,6 +67,7 @@ dependencies {
   // ml deps
   api project(':libs:elasticsearch-grok')
   api "net.sf.supercsv:super-csv:${versions.supercsv}"
+  api "org.apache.commons:commons-math3:3.6.1"
   nativeBundle("org.elasticsearch.ml:ml-cpp:${project.version}@zip") {
     changing = true
   }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -139,6 +139,7 @@ import org.elasticsearch.xpack.core.ml.action.RevertModelSnapshotAction;
 import org.elasticsearch.xpack.core.ml.action.SetUpgradeModeAction;
 import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
+import org.elasticsearch.xpack.core.ml.action.StartInvestigationAction;
 import org.elasticsearch.xpack.core.ml.action.StopDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.StopDatafeedAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateCalendarJobAction;
@@ -219,6 +220,7 @@ import org.elasticsearch.xpack.ml.action.TransportRevertModelSnapshotAction;
 import org.elasticsearch.xpack.ml.action.TransportSetUpgradeModeAction;
 import org.elasticsearch.xpack.ml.action.TransportStartDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.ml.action.TransportStartDatafeedAction;
+import org.elasticsearch.xpack.ml.action.TransportStartInvestigationAction;
 import org.elasticsearch.xpack.ml.action.TransportStopDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.ml.action.TransportStopDatafeedAction;
 import org.elasticsearch.xpack.ml.action.TransportUpdateCalendarJobAction;
@@ -329,6 +331,7 @@ import org.elasticsearch.xpack.ml.rest.inference.RestGetTrainedModelsAction;
 import org.elasticsearch.xpack.ml.rest.inference.RestGetTrainedModelsStatsAction;
 import org.elasticsearch.xpack.ml.rest.inference.RestPutTrainedModelAction;
 import org.elasticsearch.xpack.ml.rest.inference.RestPutTrainedModelAliasAction;
+import org.elasticsearch.xpack.ml.rest.investigation.RestStartInvestigationAction;
 import org.elasticsearch.xpack.ml.rest.job.RestCloseJobAction;
 import org.elasticsearch.xpack.ml.rest.job.RestDeleteForecastAction;
 import org.elasticsearch.xpack.ml.rest.job.RestDeleteJobAction;
@@ -953,6 +956,7 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
             new RestPutTrainedModelAliasAction(),
             new RestDeleteTrainedModelAliasAction(),
             new RestPreviewDataFrameAnalyticsAction(),
+            new RestStartInvestigationAction(),
             // CAT Handlers
             new RestCatJobsAction(),
             new RestCatTrainedModelsAction(),
@@ -1039,7 +1043,8 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
                 new ActionHandler<>(PutTrainedModelAliasAction.INSTANCE, TransportPutTrainedModelAliasAction.class),
                 new ActionHandler<>(DeleteTrainedModelAliasAction.INSTANCE, TransportDeleteTrainedModelAliasAction.class),
                 new ActionHandler<>(PreviewDataFrameAnalyticsAction.INSTANCE, TransportPreviewDataFrameAnalyticsAction.class),
-                usageAction,
+                new ActionHandler<>(StartInvestigationAction.INSTANCE, TransportStartInvestigationAction.class),
+            usageAction,
                 infoAction);
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartInvestigationAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartInvestigationAction.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.ml.action;
+
+import org.apache.commons.math3.stat.correlation.PearsonsCorrelation;
+import org.apache.commons.math3.stat.inference.KolmogorovSmirnovTest;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
+import org.elasticsearch.search.aggregations.bucket.composite.TermsValuesSourceBuilder;
+import org.elasticsearch.search.aggregations.bucket.range.Range;
+import org.elasticsearch.search.aggregations.bucket.range.RangeAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.Percentiles;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.ml.action.StartInvestigationAction;
+import org.elasticsearch.xpack.core.ml.action.StartInvestigationAction.Request;
+import org.elasticsearch.xpack.core.ml.action.StartInvestigationAction.Response;
+import org.elasticsearch.xpack.core.security.SecurityContext;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+
+public class TransportStartInvestigationAction extends HandledTransportAction<Request, Response> {
+
+    private final ThreadPool threadPool;
+    private final Client client;
+    private final NamedXContentRegistry xContentRegistry;
+    private final SecurityContext securityContext;
+
+    @Inject
+    public TransportStartInvestigationAction(Settings settings, ThreadPool threadPool, TransportService transportService,
+                                             ActionFilters actionFilters, Client client,
+                                             NamedXContentRegistry xContentRegistry) {
+        super(StartInvestigationAction.NAME, transportService, actionFilters, Request::new);
+        this.threadPool = threadPool;
+        this.client = client;
+        this.xContentRegistry = xContentRegistry;
+        this.securityContext = XPackSettings.SECURITY_ENABLED.get(settings) ?
+            new SecurityContext(settings, threadPool.getThreadContext()) : null;
+    }
+
+    @Override
+    protected void doExecute(Task task, Request request, ActionListener<Response> listener) {
+        threadPool.generic().execute(() -> investigate(request, listener));
+    }
+
+    void investigate(Request request, ActionListener<Response> listener) {
+        final String termField = request.getConfig().getTerms().get(0);
+        Correlator correlator = new Correlator(termField);
+        client.prepareSearch("correlation_demo")
+            .setSource(correlator.rangeQuery())
+            .execute(ActionListener.wrap(
+                searchResponse -> {
+                    AggregationBuilder metricAgg = correlator.buildRangeAggAndSetExpectations(searchResponse.getAggregations());
+                    client.prepareSearch("correlation_demo").addAggregation(
+                        AggregationBuilders.composite(
+                            "correlation_composite",
+                            List.of(new TermsValuesSourceBuilder(termField).field(termField))
+                        ).subAggregation(metricAgg).size(10000) // TODO actually scroll just all for now
+                    ).setSize(0).execute(
+                        ActionListener.wrap(
+                            compositeSearchResponse -> {
+                                CompositeAggregation agg = compositeSearchResponse.getAggregations().get("correlation_composite");
+                                for (CompositeAggregation.Bucket bucket : agg.getBuckets()) {
+                                    correlator.handleBucket(bucket);
+                                }
+                                listener.onResponse(new Response(correlator.results));
+                            },
+                            listener::onFailure
+                        )
+                    );
+                },
+                listener::onFailure
+            ));
+
+    }
+
+    static class Correlator {
+
+        private Map<String, Object> compositePage;
+        private List<Map<String, Object>> results = new ArrayList<>();
+        private double[] expectations;
+        private final String termField;
+        private final KolmogorovSmirnovTest ks2Test = new KolmogorovSmirnovTest();
+        private static final double[] PERCENTILE_STEPS = IntStream.range(2, 99)
+            .filter(i -> i % 2 == 0)
+            .mapToDouble(Double::valueOf)
+            .toArray();
+
+        Correlator(String termField) {
+            this.termField = termField;
+        }
+
+        SearchSourceBuilder rangeQuery() {
+            return SearchSourceBuilder.searchSource()
+                .aggregation(
+                    AggregationBuilders.percentiles("correlation_percentiles")
+                        .field("latency")
+                        .percentiles(PERCENTILE_STEPS)
+                )
+                .size(0)
+                .trackTotalHits(true);
+        }
+
+        AggregationBuilder buildRangeAggAndSetExpectations(Aggregations aggregations) {
+            Percentiles percentiles = aggregations.get("correlation_percentiles");
+            expectations = new double[PERCENTILE_STEPS.length + 1];
+            RangeAggregationBuilder builder = AggregationBuilders.range("correlation_range").field("latency");
+            double percentile_0 = percentiles.percentile(PERCENTILE_STEPS[0]);
+            builder.addUnboundedTo(percentile_0);
+            expectations[0] = percentile_0;
+            for (int i = 1; i < PERCENTILE_STEPS.length; i++) {
+                double percentile_l = percentiles.percentile(PERCENTILE_STEPS[i - 1]);
+                double percentile_r = percentiles.percentile(PERCENTILE_STEPS[i]);
+                builder.addRange(percentile_l, percentile_r);
+                expectations[i] = 0.5 * (percentile_l + percentile_r);
+            }
+            double percentile_n = percentiles.percentile(PERCENTILE_STEPS[PERCENTILE_STEPS.length - 1]);
+            builder.addUnboundedFrom(percentile_n);
+            expectations[PERCENTILE_STEPS.length] = percentile_n;
+            return builder;
+        }
+
+        void handleBucket(CompositeAggregation.Bucket bucket) {
+            String term = bucket.getKey().get(termField).toString();
+            Range termRanges = bucket.getAggregations().get("correlation_range");
+            final int l = termRanges.getBuckets().size();
+            final int a = (int) (l / 5.0 + 0.5);
+            final int b = (int) (4.0 * l / 5.0 + 0.5);
+            long[] x_b = LongStream.range(0, a)
+                .map(i -> termRanges.getBuckets().get((int)i).getDocCount())
+                .toArray();
+            long[] x_a = LongStream.range(a, l)
+                .map(i -> termRanges.getBuckets().get((int)i).getDocCount())
+                .toArray();
+            double[] counts = termRanges.getBuckets()
+                .stream()
+                .mapToLong(MultiBucketsAggregation.Bucket::getDocCount)
+                .mapToDouble(Double::valueOf)
+                .toArray();
+            PearsonsCorrelation pearsonsCorrelation = new PearsonsCorrelation();
+            double corr = pearsonsCorrelation.correlation(expectations, counts);
+            results.add(Collections.singletonMap(term, corr));
+        }
+
+    }
+
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/investigation/RestStartInvestigationAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/investigation/RestStartInvestigationAction.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.rest.investigation;
+
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.RestApiVersion;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.ml.action.DeleteTrainedModelAction;
+import org.elasticsearch.xpack.core.ml.action.StartInvestigationAction;
+import org.elasticsearch.xpack.core.ml.investigation.InvestigationConfig;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+import static org.elasticsearch.xpack.ml.MachineLearning.BASE_PATH;
+
+public class RestStartInvestigationAction extends BaseRestHandler {
+
+    @Override
+    public List<Route> routes() {
+        return List.of(
+            new Route(POST, BASE_PATH + "investigation/_start")
+        );
+    }
+
+    @Override
+    public String getName() {
+        return "ml_start_investigation_action";
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+        InvestigationConfig config = InvestigationConfig.PARSER.apply(restRequest.contentParser(), null);
+
+        return channel -> client.execute(StartInvestigationAction.INSTANCE,
+            new StartInvestigationAction.Request(config),
+            new RestToXContentListener<>(channel));
+    }
+}


### PR DESCRIPTION
To do an investigation:

```
POST _ml/investigation/_start
{
    "key_indicator": "latency",
    "terms": ["browser.keyword"],
    "source_config": {
        // also supports runtime_mappings
        "index": ["correlation_demo"],
        "query": {"exists": {"field": "browser"}}

    }
}
```

This does an individual composite agg for each of the `terms` values and correlates them with the latency. This is VERY POC, not production ready. 

This honestly should probably be a pipeline or a metric aggregation.